### PR TITLE
Include trepanxpy.processor module in pyproject for setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ ignore = ["dist", "docs", "tmp", ".cache"]
 [tool.setuptools]
 packages = [
     "trepanxpy",
+    "trepanxpy.processor",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Fixes #1 as now the `trepanxpy/processor` dir is included as a module in the `pyproject.toml`, making installation through uv work

<img width="631" height="164" alt="image" src="https://github.com/user-attachments/assets/abbe6a9c-bcad-4a0e-9c9c-545f83dd2894" />
